### PR TITLE
Fix thread amount explosion under >500tps

### DIFF
--- a/src/main/scala/com/example/fs2kafkatest/Fs2kafkatestRoutes.scala
+++ b/src/main/scala/com/example/fs2kafkatest/Fs2kafkatestRoutes.scala
@@ -7,21 +7,23 @@ import org.http4s.dsl.Http4sDsl
 
 object Fs2kafkatestRoutes {
 
-  def jokeRoutes[F[_]: Sync](J: Jokes[F], K: KafkaSender[F]): HttpRoutes[F] = {
-    val dsl = new Http4sDsl[F]{}
+  def jokeRoutes[F[_]: Sync](J: Jokes[F]): HttpRoutes[F] = {
+    val dsl = new Http4sDsl[F] {}
     import dsl._
     HttpRoutes.of[F] {
       case GET -> Root / "joke" =>
         for {
           joke <- J.get
-          _ <- K.send(joke.joke)
           resp <- Ok(joke)
         } yield resp
     }
   }
 
-  def helloWorldRoutes[F[_]: Sync](H: HelloWorld[F], K: KafkaSender[F]): HttpRoutes[F] = {
-    val dsl = new Http4sDsl[F]{}
+  def helloWorldRoutes[F[_]: Sync](
+      H: HelloWorld[F],
+      K: KafkaSender[F]
+  ): HttpRoutes[F] = {
+    val dsl = new Http4sDsl[F] {}
     import dsl._
     HttpRoutes.of[F] {
       case GET -> Root / "hello" / name =>

--- a/src/main/scala/com/example/fs2kafkatest/Fs2kafkatestServer.scala
+++ b/src/main/scala/com/example/fs2kafkatest/Fs2kafkatestServer.scala
@@ -8,14 +8,21 @@ import org.http4s.implicits._
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.server.middleware.Logger
 import scala.concurrent.ExecutionContext.global
+import fs2.kafka._
 
 object Fs2kafkatestServer {
 
-  def stream[F[_]: ConcurrentEffect: ContextShift](implicit T: Timer[F]/*, C: ContextShift[F]*/): Stream[F, Nothing] = {
+  def stream[F[_]: ConcurrentEffect: ContextShift](implicit
+      T: Timer[F] /*, C: ContextShift[F]*/
+  ): Stream[F, Nothing] = {
     for {
       client <- BlazeClientBuilder[F](global).stream
+      producerSettings =
+        ProducerSettings[F, String, String]
+          .withBootstrapServers("localhost:9092")
+      producer <- producerStream[F].using(producerSettings)
       helloWorldAlg = HelloWorld.impl[F]
-      kafkaAlg = KafkaSender.impl[F]
+      kafkaAlg = KafkaSender.impl[F](producer)
       jokeAlg = Jokes.impl[F](client)
 
       // Combine Service Routes into an HttpApp.
@@ -23,8 +30,8 @@ object Fs2kafkatestServer {
       // want to extract a segments not checked
       // in the underlying routes.
       httpApp = (
-        Fs2kafkatestRoutes.helloWorldRoutes[F](helloWorldAlg, kafkaAlg) <+>
-        Fs2kafkatestRoutes.jokeRoutes[F](jokeAlg, kafkaAlg)
+          Fs2kafkatestRoutes.helloWorldRoutes[F](helloWorldAlg, kafkaAlg) <+>
+            Fs2kafkatestRoutes.jokeRoutes[F](jokeAlg)
       ).orNotFound
 
       // With Middlewares in place

--- a/src/main/scala/com/example/fs2kafkatest/KafkaSender.scala
+++ b/src/main/scala/com/example/fs2kafkatest/KafkaSender.scala
@@ -1,8 +1,7 @@
 package com.example.fs2kafkatest
 
-import cats.effect._
-import cats.implicits._
 import cats._
+import cats.implicits._
 import fs2.kafka._
 
 trait KafkaSender[F[_]] {
@@ -10,25 +9,17 @@ trait KafkaSender[F[_]] {
 }
 
 object KafkaSender {
-  def impl[F[_]: ConcurrentEffect: ContextShift: FlatMap] = {
-    val producerSettings =
-      ProducerSettings[F, String, String]
-        .withBootstrapServers("localhost:9092")
-
-    val resource = producerResource[F].using(producerSettings)
+  def impl[F[_]: FlatMap](producer: KafkaProducer[F, String, String]) = {
 
     new KafkaSender[F] {
       override def send(event: String) =
-        resource
-          .use(producer =>
-            producer
-              .produce(
-                ProducerRecords.one(
-                  ProducerRecord("jokes", "test-key", event)
-                )
-              )
-              .flatten
+        producer
+          .produce(
+            ProducerRecords.one(
+              ProducerRecord("hellos-2", "test-key", event)
+            )
           )
+          .flatten
     }
   }
 }


### PR DESCRIPTION
By reusing KafkaProducer instead of instantiating every request.